### PR TITLE
Week calendar, flexible slot time limits and clickable ressources

### DIFF
--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -19,8 +19,9 @@ export const calendarOptions = {
 Salle: ${event.resourceIds[0]}
 Début: ${event.start?.toLocaleString('fr-FR', dateOptions)} (Europe/Paris)
 Fin:   ${event.end?.toLocaleString('fr-FR', dateOptions)} (Europe/Paris)`),
-	slotMinTime: '07:00',
-	slotMaxTime: '21:00',
+	slotMinTime: '08:00',
+	slotMaxTime: '18:00',
+	flexibleSlotTimeLimits: true,
 	allDaySlot: false,
 	nowIndicator: true,
 	locale: 'fr',

--- a/src/routes/(app)/calendar/+page.svelte
+++ b/src/routes/(app)/calendar/+page.svelte
@@ -72,7 +72,10 @@
 							end: 'prev,next today',
 						},
 						events: rooms?.map((room) => parseEvents(room?.events)).flat(),
-						resources: rooms?.map((room) => room.resource),
+						resources: rooms?.map(({ resource }) => ({
+							id: resource.id,
+							title: {html: `<a href="rooms/${resource.id}">${resource.title}</a>`}
+						})),
 				}}
 				/>
 			{/if}

--- a/src/routes/(app)/calendar/+page.svelte
+++ b/src/routes/(app)/calendar/+page.svelte
@@ -66,6 +66,11 @@
 					options={{
 						...calendarOptions,
 						view: 'resourceTimeGridDay',
+						headerToolbar: {
+							start: '',
+							center: 'title',
+							end: 'prev,next today',
+						},
 						events: rooms?.map((room) => parseEvents(room?.events)).flat(),
 						resources: rooms?.map((room) => room.resource),
 				}}

--- a/src/routes/(app)/rooms/[roomID]/+page.svelte
+++ b/src/routes/(app)/rooms/[roomID]/+page.svelte
@@ -46,6 +46,11 @@
 				options={{
 				...calendarOptions,
 				view: 'resourceTimeGridDay',
+				headerToolbar: {
+					start: 'resourceTimeGridDay,resourceTimeGridWeek',
+					center: 'title',
+					end: 'prev,next today',
+				},
 				events: parseEvents(response.room.events),
 				resources: [response.room.resource],
 			}}


### PR DESCRIPTION
Adds:
- A week view for individual room view
- Dynamic limits time for time slots (with default being reduced to 8h-18h)
- Clickable ressources in multi-room calendar view linking to their corresponding calendar pages